### PR TITLE
create-user-db requires a password param and is idempotent

### DIFF
--- a/root/usr/bin/create-citus-in-db
+++ b/root/usr/bin/create-citus-in-db
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e
 
 # =============================================================================
 # Usage:
@@ -20,4 +21,4 @@ if [ "$#" -ne 1 ]; then
     usage
 fi
 
-psql -qtA -v "ON_ERROR_STOP=1" -d "$1" <<< "CREATE EXTENSION citus;"
+psql -qtA -v "ON_ERROR_STOP=1" -d "$1" <<< "create extension if not exists citus;"

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -29,6 +29,7 @@ _psql() {
     PGOPTIONS='--client-min-messages=warning' psql -qtA --set ON_ERROR_STOP=1 "$@" 2>&1
 }
 
+create_db_query="create database $db;"
 read -r -d '' create_db_query_workers<<EOF
 select nodename, success, result from run_command_on_workers('$create_db_query');
 EOF

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -26,10 +26,9 @@ user=$1
 db=$2
 
 _psql() {
-    PGOPTIONS='--client-min-messages=warning' psql -qtA --set ON_ERROR_STOP=1 "$@"
+    PGOPTIONS='--client-min-messages=warning' psql -qtA --set ON_ERROR_STOP=1 "$@" 2>&1
 }
 
-create_db_query="create database $db;"
 read -r -d '' create_db_query_workers<<EOF
 select nodename, success, result from run_command_on_workers('$create_db_query');
 EOF
@@ -52,7 +51,7 @@ if [ "$coordinator_out" == "ERROR:  database \"$db\" already exists" ]; then
     echo "Database \"$db\" already exists on coordinator node"
 elif [[ $coordinator_out == ERROR* ]]; then
     echo "$coordinator_out"
-    #exit 1
+    exit 1
 fi
 
 # Create DB on the workers
@@ -65,7 +64,7 @@ do
             echo "Database \"$db\" already exists on worker node ${worker_out_fields[0]}"
         else
             echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
-            #exit 1
+            exit 1
         fi
     fi
 done
@@ -75,7 +74,7 @@ if [ "$coordinator_out" == "ERROR:  role \"$user\" already exists" ]; then
     echo "User \"$user\" already exists on coordinator node"
 elif [[ $coordinator_out == ERROR* ]]; then
     echo "$coordinator_out"
-    #exit 1
+    exit 1
 fi
 
 # Create user on the workers
@@ -88,7 +87,7 @@ do
             echo "User \"$user\" already exists on worker node ${worker_out_fields[0]}"
         else
             echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
-            #exit 1
+            exit 1
         fi
     fi
 done

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -8,25 +8,25 @@ usage() {
     cat << EOF
 $0
 
-Creates a database and a user with a generated password.
+Creates a database and a user with the given password.
 Grants all privileges on the database to the created user.
 
-Usage: $0 USER DATABASE PASSWORD_LENGTH=16
+Usage: $0 USER DATABASE PASSWORD
 EOF
     exit 1
 }
 
-if [ "$#" -ne 2 ] && [ "$#" -ne 3 ]; then
-    echo "Passed $# parameters. Expected 2 or 3."
+if [ "$#" -ne 3 ]; then
+    echo "Passed $# parameters. Expected 3."
     usage
 fi
 
-password=$(< /dev/urandom tr -dc _A-Za-z0-9- | head -c"${3:-16}";echo;)
+password=$3
 user=$1
 db=$2
 
 _psql() {
-    psql_out=$(PGOPTIONS='--client-min-messages=warning' psql -qtA --set ON_ERROR_STOP=1 "$@")
+    PGOPTIONS='--client-min-messages=warning' psql -qtA --set ON_ERROR_STOP=1 "$@"
 }
 
 create_db_query="create database $db;"
@@ -57,5 +57,3 @@ for worker_node in "${worker_nodes[@]}"
 do
  _psql -d "$db" -c "select * from master_add_node('$worker_node', 5432);"
 done
-
-echo -n "$password"

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -41,19 +41,71 @@ escaped_create_user_query="${create_user_query//\'/\'\'}"
 
 read -ra worker_nodes<<<"$(_psql -c 'select node_name from master_get_active_worker_nodes();')"
 
-_psql << EOF
-    $create_db_query
-    select run_command_on_workers('$create_db_query');
-EOF
+# Create DB on the coordinator
+coordinator_out=$(_psql -c "$create_db_query")
+if [ "$coordinator_out" == "ERROR:  database \"$db\" already exists" ]; then
+    echo "Database \"$db\" already exists on coordinator node"
+elif [[ $coordinator_out == ERROR* ]]; then
+    echo "$coordinator_out"
+    exit 1
+fi
 
-_psql << EOF
-    $create_user_query
-    select run_command_on_workers('$escaped_create_user_query');
-EOF
+# Create DB on the workers
+read -ra create_db_workers_out<<<"$(_psql -c "select nodename, success, result from run_command_on_workers(\'$create_db_query\');")"
+for worker_out in "${create_db_workers_out[@]}"
+do
+    IFS='|' read -r -a worker_out_fields <<< "$worker_out"
+    if [ "${worker_out_fields[1]}" == "f" ]; then
+        if [ "${worker_out_fields[1]}" == "ERROR:  database \"$db\" already exists" ]; then
+            echo "Database \"$db\" already exists on worker node ${worker_out_fields[0]}"
+        else
+            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[1]}"
+            exit 1
+        fi
+    fi
+done
 
-_psql -d "$db" -c "create extension citus;"
+# Register the workers in the newly created DB
+for worker_node in "${worker_nodes[@]}"
+do
+ _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"
+done
+
+
+coordinator_out=$(_psql -c "$create_user_query")
+if [ "$coordinator_out" == "ERROR:  role \"$user\" already exists" ]; then
+    echo "User \"$user\" already exists on coordinator node"
+elif [[ $coordinator_out == ERROR* ]]; then
+    echo "$coordinator_out"
+    exit 1
+fi
+
+# Create user on the workers
+read -ra create_db_workers_out<<<"$(_psql -c "select nodename, success, result from run_command_on_workers(\'$escaped_create_user_query\')")"
+for worker_out in "${create_db_workers_out[@]}"
+do
+    IFS='|' read -r -a worker_out_fields <<< "$worker_out"
+    if [ "${worker_out_fields[1]}" == "f" ]; then
+        if [ "${worker_out_fields[1]}" == "ERROR:  role \"$user\" already exists" ]; then
+            echo "User \"$user\" already exists on worker node ${worker_out_fields[0]}"
+        else
+            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[1]}"
+            exit 1
+        fi
+    fi
+done
+
+coordinator_out=$(_psql -d "$db" -c "create extension citus;")
+if [ "$coordinator_out" == "ERROR:  extension \"citus\" already exists" ]; then
+    echo "Extension citus already exists on coordinator node"
+elif [[ $coordinator_out == ERROR* ]]; then
+    echo "$coordinator_out"
+    exit 1
+fi
 
 for worker_node in "${worker_nodes[@]}"
 do
  _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"
 done
+
+exit 0

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -56,10 +56,10 @@ for worker_out in "${create_db_workers_out[@]}"
 do
     IFS='|' read -r -a worker_out_fields <<< "$worker_out"
     if [ "${worker_out_fields[1]}" == "f" ]; then
-        if [ "${worker_out_fields[1]}" == "ERROR:  database \"$db\" already exists" ]; then
+        if [ "${worker_out_fields[2]}" == "ERROR:  database \"$db\" already exists" ]; then
             echo "Database \"$db\" already exists on worker node ${worker_out_fields[0]}"
         else
-            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[1]}"
+            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
             exit 1
         fi
     fi
@@ -74,27 +74,21 @@ elif [[ $coordinator_out == ERROR* ]]; then
 fi
 
 # Create user on the workers
-read -ra create_db_workers_out<<<"$(_psql -c $'select nodename, success, result from run_command_on_workers(\'$escaped_create_user_query\')')"
+read -ra create_db_workers_out<<<"$(_psql -c 'select nodename, success, result from run_command_on_workers('"'""$escaped_create_user_query""'"')')"
 for worker_out in "${create_db_workers_out[@]}"
 do
     IFS='|' read -r -a worker_out_fields <<< "$worker_out"
     if [ "${worker_out_fields[1]}" == "f" ]; then
-        if [ "${worker_out_fields[1]}" == "ERROR:  role \"$user\" already exists" ]; then
+        if [ "${worker_out_fields[2]}" == "ERROR:  role \"$user\" already exists" ]; then
             echo "User \"$user\" already exists on worker node ${worker_out_fields[0]}"
         else
-            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[1]}"
+            echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
             exit 1
         fi
     fi
 done
 
-coordinator_out=$(_psql -d "$db" -c "create extension citus;")
-if [ "$coordinator_out" == "ERROR:  extension \"citus\" already exists" ]; then
-    echo "Extension citus already exists on coordinator node"
-elif [[ $coordinator_out == ERROR* ]]; then
-    echo "$coordinator_out"
-    exit 1
-fi
+_psql -d "$db" -c "create extension if not exists citus;"
 
 # Register the workers in the newly created DB
 for worker_node in "${worker_nodes[@]}"

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -43,17 +43,17 @@ read -ra worker_nodes<<<"$(_psql -c 'select node_name from master_get_active_wor
 
 _psql << EOF
     $create_db_query
-    select * from run_command_on_workers('$create_db_query');
+    select run_command_on_workers('$create_db_query');
 EOF
 
 _psql << EOF
     $create_user_query
-    select * from run_command_on_workers('$escaped_create_user_query');
+    select run_command_on_workers('$escaped_create_user_query');
 EOF
 
 _psql -d "$db" -c "create extension citus;"
 
 for worker_node in "${worker_nodes[@]}"
 do
- _psql -d "$db" -c "select * from master_add_node('$worker_node', 5432);"
+ _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"
 done

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -30,6 +30,9 @@ _psql() {
 }
 
 create_db_query="create database $db;"
+read -r -d '' create_db_query_workers<<EOF
+select nodename, success, result from run_command_on_workers('$create_db_query');
+EOF
 read -r -d '' create_user_query<<EOF
 create user $user with encrypted password '$password';
 revoke all on database $db from public;
@@ -37,7 +40,9 @@ revoke all on database postgres from $user;
 grant all on database $db to $user;
 alter database $db owner to $user;
 EOF
-escaped_create_user_query="${create_user_query//\'/\'\'}"
+read -r -d '' create_user_query_workers<<EOF
+select nodename, success, result from run_command_on_workers('${create_user_query//\'/\'\'}');
+EOF
 
 read -ra worker_nodes<<<"$(_psql -c 'select node_name from master_get_active_worker_nodes();')"
 
@@ -47,11 +52,11 @@ if [ "$coordinator_out" == "ERROR:  database \"$db\" already exists" ]; then
     echo "Database \"$db\" already exists on coordinator node"
 elif [[ $coordinator_out == ERROR* ]]; then
     echo "$coordinator_out"
-    exit 1
+    #exit 1
 fi
 
 # Create DB on the workers
-read -ra create_db_workers_out<<<"$(_psql -c $'select nodename, success, result from run_command_on_workers(\'$create_db_query\');')"
+mapfile -t create_db_workers_out<<<"$(_psql <<< "$create_db_query_workers")"
 for worker_out in "${create_db_workers_out[@]}"
 do
     IFS='|' read -r -a worker_out_fields <<< "$worker_out"
@@ -60,30 +65,30 @@ do
             echo "Database \"$db\" already exists on worker node ${worker_out_fields[0]}"
         else
             echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
-            exit 1
+            #exit 1
         fi
     fi
 done
 
-coordinator_out=$(_psql -c "$create_user_query")
+coordinator_out=$(_psql <<< "$create_user_query")
 if [ "$coordinator_out" == "ERROR:  role \"$user\" already exists" ]; then
     echo "User \"$user\" already exists on coordinator node"
 elif [[ $coordinator_out == ERROR* ]]; then
     echo "$coordinator_out"
-    exit 1
+    #exit 1
 fi
 
 # Create user on the workers
-read -ra create_db_workers_out<<<"$(_psql -c 'select nodename, success, result from run_command_on_workers('"'""$escaped_create_user_query""'"')')"
+mapfile -t create_db_workers_out <<< "$(_psql <<< "$create_user_query_workers")"
 for worker_out in "${create_db_workers_out[@]}"
 do
-    IFS='|' read -r -a worker_out_fields <<< "$worker_out"
+    IFS='|' read -ra worker_out_fields <<< "$worker_out"
     if [ "${worker_out_fields[1]}" == "f" ]; then
         if [ "${worker_out_fields[2]}" == "ERROR:  role \"$user\" already exists" ]; then
             echo "User \"$user\" already exists on worker node ${worker_out_fields[0]}"
         else
             echo "Error on worker ${worker_out_fields[0]}: ${worker_out_fields[2]}"
-            exit 1
+            #exit 1
         fi
     fi
 done
@@ -93,7 +98,7 @@ _psql -d "$db" -c "create extension if not exists citus;"
 # Register the workers in the newly created DB
 for worker_node in "${worker_nodes[@]}"
 do
- _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"
+ _psql -d "$db" -c "select master_add_node('$worker_node', 5432);" > /dev/null
 done
 
 exit 0

--- a/root/usr/bin/create-user-db
+++ b/root/usr/bin/create-user-db
@@ -51,7 +51,7 @@ elif [[ $coordinator_out == ERROR* ]]; then
 fi
 
 # Create DB on the workers
-read -ra create_db_workers_out<<<"$(_psql -c "select nodename, success, result from run_command_on_workers(\'$create_db_query\');")"
+read -ra create_db_workers_out<<<"$(_psql -c $'select nodename, success, result from run_command_on_workers(\'$create_db_query\');')"
 for worker_out in "${create_db_workers_out[@]}"
 do
     IFS='|' read -r -a worker_out_fields <<< "$worker_out"
@@ -65,13 +65,6 @@ do
     fi
 done
 
-# Register the workers in the newly created DB
-for worker_node in "${worker_nodes[@]}"
-do
- _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"
-done
-
-
 coordinator_out=$(_psql -c "$create_user_query")
 if [ "$coordinator_out" == "ERROR:  role \"$user\" already exists" ]; then
     echo "User \"$user\" already exists on coordinator node"
@@ -81,7 +74,7 @@ elif [[ $coordinator_out == ERROR* ]]; then
 fi
 
 # Create user on the workers
-read -ra create_db_workers_out<<<"$(_psql -c "select nodename, success, result from run_command_on_workers(\'$escaped_create_user_query\')")"
+read -ra create_db_workers_out<<<"$(_psql -c $'select nodename, success, result from run_command_on_workers(\'$escaped_create_user_query\')')"
 for worker_out in "${create_db_workers_out[@]}"
 do
     IFS='|' read -r -a worker_out_fields <<< "$worker_out"
@@ -103,6 +96,7 @@ elif [[ $coordinator_out == ERROR* ]]; then
     exit 1
 fi
 
+# Register the workers in the newly created DB
 for worker_node in "${worker_nodes[@]}"
 do
  _psql -d "$db" -c "select master_add_node('$worker_node', 5432);"

--- a/test/e2e/create-user-db/create-user-db-test.bats
+++ b/test/e2e/create-user-db/create-user-db-test.bats
@@ -18,14 +18,14 @@ teardown() {
 }
 
 @test "create-user-db creates a user that can log in to the db" {
-  $(make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password")
+  make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
   run make --no-print-directory -f "${fixture}" test-user-password USER="$user" DB="$db" PASS="$password"
   echo "${lines[@]}" # prints the lines if test fails
   [ "$(echo -e "${lines[0]}" | tr -d '[:space:]')" == "ok" ]
 }
 
 @test "create-user-db creates a user that fails to log in with the wrong password" {
-  $(make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password")
+  make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
   run make --no-print-directory -f "${fixture}" test-user-password USER="$user" DB="$db" PASS="wrongpassword"
   echo "${lines[@]}" # prints the lines if test fails
   [ "${lines[0]}" == "psql: FATAL:  password authentication failed for user \"$user\"" ]

--- a/test/e2e/create-user-db/create-user-db-test.bats
+++ b/test/e2e/create-user-db/create-user-db-test.bats
@@ -1,32 +1,32 @@
 #!/usr/bin/env bats
 
 setup() {
-  USER='foo'
-  DB='foodb'
-  PASS_LEN=32
+  user='foo'
+  db='foodb'
+  password='foopass'
   fixture="${BATS_TEST_DIRNAME}/create-user-db-test.mk"
 }
 
 teardown() {
-  make --no-print-directory -f "${fixture}" drop-user-db USER="$USER" DB="$DB"
+  make --no-print-directory -f "${fixture}" drop-user-db USER="$user" DB="$db"
 }
 
-@test "create-user-db prints a password" {
-  run make --no-print-directory -f "${fixture}" create-user-db USER="$USER" DB="$DB" PASS_LEN="$PASS_LEN"
+@test "create-user-db exits with code 0" {
+  run make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
   echo "${lines[@]}" # prints the lines if test fails
-  [ "${#lines[0]}" -eq "$PASS_LEN" ]
+  [ "${status}" -eq 0 ]
 }
 
 @test "create-user-db creates a user that can log in to the db" {
-  PASS=$(make --no-print-directory -f "${fixture}" create-user-db USER="$USER" DB="$DB" PASS_LEN="$PASS_LEN")
-  run make --no-print-directory -f "${fixture}" test-user-password USER="$USER" DB="$DB" PASS="$PASS"
+  $(make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password")
+  run make --no-print-directory -f "${fixture}" test-user-password USER="$user" DB="$db" PASS="$password"
   echo "${lines[@]}" # prints the lines if test fails
   [ "$(echo -e "${lines[0]}" | tr -d '[:space:]')" == "ok" ]
 }
 
 @test "create-user-db creates a user that fails to log in with the wrong password" {
-  PASS=$(make --no-print-directory -f "${fixture}" create-user-db USER="$USER" DB="$DB" PASS_LEN="$PASS_LEN")
-  run make --no-print-directory -f "${fixture}" test-user-password USER="$USER" DB="$DB" PASS="wrongpassword"
+  $(make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password")
+  run make --no-print-directory -f "${fixture}" test-user-password USER="$user" DB="$db" PASS="wrongpassword"
   echo "${lines[@]}" # prints the lines if test fails
-  [ "${lines[0]}" == "psql: FATAL:  password authentication failed for user \"$USER\"" ]
+  [ "${lines[0]}" == "psql: FATAL:  password authentication failed for user \"$user\"" ]
 }

--- a/test/e2e/create-user-db/create-user-db-test.bats
+++ b/test/e2e/create-user-db/create-user-db-test.bats
@@ -24,6 +24,13 @@ teardown() {
   [ "$(echo -e "${lines[0]}" | tr -d '[:space:]')" == "ok" ]
 }
 
+@test "create-user-db is idempotent" {
+  make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
+  run make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
+  echo "${lines[@]}" # prints the lines if test fails
+  [ "${status}" -eq 0 ]
+}
+
 @test "create-user-db creates a user that fails to log in with the wrong password" {
   make --no-print-directory -f "${fixture}" create-user-db USER="$user" DB="$db" PASS="$password"
   run make --no-print-directory -f "${fixture}" test-user-password USER="$user" DB="$db" PASS="wrongpassword"

--- a/test/e2e/create-user-db/create-user-db-test.mk
+++ b/test/e2e/create-user-db/create-user-db-test.mk
@@ -3,7 +3,7 @@ include $(abspath $(realpath $(lastword $(MAKEFILE_LIST)))/../../../../.pipeline
 
 .PHONY: create-user-db
 create-user-db:
-	$(call oc_exec_all_pods,cas-postgres-master,create-user-db $(USER) $(DB) $(PASS_LEN))
+	$(call oc_exec_all_pods,cas-postgres-master,create-user-db $(USER) $(DB) $(PASS))
 	$(call oc_exec_all_pods,cas-postgres-workers,create-citus-in-db $(DB))
 
 .PHONY: drop-user-db

--- a/test/unit/create-user-db-test.bats
+++ b/test/unit/create-user-db-test.bats
@@ -13,24 +13,24 @@ teardown() {
     fi
 }
 
-@test "create-user-db creates a user, db, and prints a password" {
+@test "create-user-db calls psql" {
 
-    USER='foo'
-    DB='bar'
-    PASS_LEN=42
+    user='foo'
+    db='bar'
+    password='baz'
     shellmock_expect psql --type regex --match ".*" --output "called psql"
-    run $CREATE_USER $USER $DB $PASS_LEN
+    run $CREATE_USER $user $db $password
     echo "${lines[@]}" # prints the lines if test fails
 
-    [ "${#lines[0]}" -eq $PASS_LEN ]
+    [ "${lines[0]}" == "called psql" ]
 }
 
-@test "create-user-db prints a password of length 16 by default" {
-    USER='foo'
-    DB='bar'
+@test "create-user-db prints an error if less than three params are passed" {
+    user='foo'
+    db='bar'
     shellmock_expect psql --type regex --match ".*" --output "called psql"
-    run $CREATE_USER $USER $DB
+    run $CREATE_USER $user $db
     echo "${lines[@]}" # prints the lines if test fails
 
-    [ "${#lines[0]}" -eq 16 ]
+    [ "${lines[0]}" == "Passed 2 parameters. Expected 3." ]
 }


### PR DESCRIPTION
This implementation relies on psql error handling and could use the `postgres_fdw` extension instead to create databases only if they exist.