### PR TITLE
Feature(tests): check installed extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   orb-tools: circleci/orb-tools@8.27.4
 
 executors:
-  default:
+  ruby:
     docker:
       - image: "circleci/ruby:2.6.4"
 
@@ -101,7 +101,7 @@ jobs:
           name: Build image on the remote cluster
 
   test-unit:
-    executor: default
+    executor: ruby
     steps:
       - orb-tools/install-bats
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ RUN INSTALL_PKGS="nss_wrapper make gcc vim-common kernel-headers zlib-devel libc
 RUN curl https://ftp.postgresql.org/pub/source/v11.4/postgresql-11.4.tar.gz | tar xz && \
     pushd postgresql-11.4 && \
     ./configure --without-readline --with-libxml && \
-    make && \
-    make install && \
+    make world && \
+    make install-world && \
     popd && \
     rm -r postgresql-11.4 && \
     localedef -f UTF-8 -i en_US en_US.UTF-8 && \

--- a/Makefile
+++ b/Makefile
@@ -149,10 +149,12 @@ endif
 
 
 .PHONY: test_e2e
-test_e2e: # https://github.com/bats-core/bats-core
-	$(call bats_test,$(call make_recursive_wildcard,$(PROJECT_FOLDER)/test/e2e,*.bats))
+test_e2e: whoami
+test_e2e: OC_PROJECT=$(OC_DEV_PROJECT)
+test_e2e:
+	@@export OC="$(OC)" OC_PROJECT="$(OC_PROJECT)" PROJECT_PREFIX="$(PROJECT_PREFIX)"; \
+		bats $(PROJECT_FOLDER)/test/e2e/**/*.bats;
 
 .PHONY: test_unit
 test_unit: # https://github.com/bats-core/bats-core
-	$(call bats_test,$(call make_recursive_wildcard,$(PROJECT_FOLDER)/test/unit,*.bats))
-
+	$(call bats_test,$(PROJECT_FOLDER)/test/unit)

--- a/test/e2e/extensions/extensions.bats
+++ b/test/e2e/extensions/extensions.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+POD=$($OC -n $OC_PROJECT get pods --selector deploymentconfig="${PROJECT_PREFIX}postgres-master" --field-selector status.phase=Running -o name | cut -d '/' -f 2 );
+
+function _psql() {
+  $OC -n $OC_PROJECT exec $POD -- psql -qtA -v 'ON_ERROR_STOP=1' -c "$1"
+}
+
+function _pg_available_extension() {
+  _psql "select default_version from pg_available_extensions where name='$1';"
+}
+
+function _pg_enabled_extension() {
+  _psql "select extversion from pg_extension where extname='$1';"
+}
+
+@test "libxml is loaded" {
+  run _psql "select '<foo>bar</foo>'::xml;";
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "<foo>bar</foo>" ]
+}
+
+@test "citus is installed" {
+  run _pg_available_extension 'citus'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "8.2-2" ]
+}
+
+@test "citus is enabled by default" {
+  run _pg_enabled_extension 'citus'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "8.2-2" ]
+}
+
+@test "pgcrypto is installed" {
+  run _pg_available_extension 'pgcrypto'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.3" ]
+}
+
+@test "pgcrypto is not enabled by default" {
+  run _pg_enabled_extension 'pgcrypto'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "plpgsql is installed" {
+  run _pg_available_extension 'plpgsql'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.0" ]
+}
+
+@test "plpgsql is enabled by default" {
+  run _pg_enabled_extension 'plpgsql'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.0" ]
+}
+
+@test "pgtap is installed" {
+  run _pg_available_extension 'pgtap'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.0.0" ]
+}
+
+@test "pgtap is not enabled by default" {
+  run _pg_enabled_extension 'pgtap'
+  echo "${lines[@]}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}


### PR DESCRIPTION
We were building core postgres but not contrib or docs. Critical core extensions like `pgcrypto` are shipped as contrib. This PR builds postgres "world" (contrib, docs, etc) and verifies the extensions we need are loaded.