### PR TITLE
deploy a cas-ciip-postgres-master instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ install: whoami
 	$(call oc_create_secrets)
 	$(call oc_promote,$(PROJECT_PREFIX)postgres)
 	$(call oc_deploy)
+	$(call oc_wait_for_deploy_ready,$(PROJECT_PREFIX)ciip-postgres-master)
 	$(call oc_wait_for_deploy_ready,$(PROJECT_PREFIX)postgres-master)
 	@@echo "TODO: wait for statefulset to be ready"
 	@@echo "waiting for all $(PROJECT_PREFIX)postgres-workers to be connected to $(PROJECT_PREFIX)postgres-master..."; \

--- a/openshift/deploy/deploymentconfig/ciip-postgres-master.yml
+++ b/openshift/deploy/deploymentconfig/ciip-postgres-master.yml
@@ -1,0 +1,126 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+
+parameters:
+  - description: Prefix to prepend to object name.
+    displayName: Prefix
+    name: PREFIX
+    required: true
+  - description: SHA1 of git revision to be deployed.
+    displayName: Git SHA1
+    name: GIT_SHA1
+    required: true
+  - description: Openshift project name
+    displayName: Project
+    name: OC_PROJECT
+    required: true
+  - description: Openshift registry URL
+    displayName: Registry
+    name: OC_REGISTRY
+    required: true
+  - description: Requested CPU
+    displayName: CPU request
+    name: MASTER_CPU_REQUEST
+    required: true
+  - description: Maximum CPU
+    displayName: CPU limit
+    name: MASTER_CPU_LIMIT
+    required: true
+  - description: Requested memory
+    displayName: Memory request
+    name: MASTER_MEMORY_REQUEST
+    required: true
+  - description: Maximum memory
+    displayName: Memory limit
+    name: MASTER_MEMORY_LIMIT
+    required: true
+
+objects:
+  - apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      name: ${PREFIX}ciip-postgres-master
+    spec:
+      strategy:
+        type: Recreate
+      replicas: 1
+      selector:
+        name: ${PREFIX}ciip-postgres-master
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            name: ${PREFIX}ciip-postgres-master
+        spec:
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          terminationGracePeriodSeconds: 3600
+          containers:
+            - env:
+                - name: POSTGRESQL_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: postgresqlAdminPassword
+                      name: ${PREFIX}ciip-postgres-master
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: postgresqlAdminPassword
+                      name: ${PREFIX}ciip-postgres-master
+                - name: POSTGRESQL_MAX_CONNECTIONS
+                  value: "1000"
+                - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+                  value: "1000"
+                - name: POSTGRESQL_SHARED_BUFFERS
+                  value: 2GB
+                - name: POSTGRESQL_EFFECTIVE_CACHE_SIZE
+                  value: 8GB
+                - name: PGDATA
+                  value: /var/lib/pgsql/data/userdata
+              image: ${OC_REGISTRY}/${OC_PROJECT}/${PREFIX}postgres:${GIT_SHA1}
+              imagePullPolicy: IfNotPresent
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                      - /usr/bin/env
+                      - bash
+                      - -c
+                      - |
+                        pg_ctl stop;
+              livenessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                    - --live
+                initialDelaySeconds: 120
+                timeoutSeconds: 30
+              name: ${PREFIX}ciip-postgres-master
+              ports:
+                - containerPort: 5432
+                  protocol: TCP
+              readinessProbe:
+                exec:
+                  command:
+                    - /usr/libexec/check-container
+                initialDelaySeconds: 5
+                timeoutSeconds: 1
+              securityContext:
+                capabilities: {}
+                privileged: false
+              terminationMessagePath: /dev/termination-log
+              volumeMounts:
+                - mountPath: /var/lib/pgsql/data
+                  name: ${PREFIX}ciip-postgres-master
+              resources:
+                limits:
+                  cpu: ${MASTER_CPU_LIMIT}
+                  memory: ${MASTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MASTER_CPU_REQUEST}
+                  memory: ${MASTER_MEMORY_REQUEST}
+          volumes:
+            - name: ${PREFIX}ciip-postgres-master
+              persistentVolumeClaim:
+                claimName: ${PREFIX}ciip-postgres-master

--- a/openshift/deploy/persistentvolumeclaim/ciip-postgres-master.yml
+++ b/openshift/deploy/persistentvolumeclaim/ciip-postgres-master.yml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+
+parameters:
+- description: Prefix to prepend to object name.
+  displayName: Prefix
+  name: PREFIX
+  required: true
+- description: SHA1 of git revision to be deployed.
+  displayName: Git SHA1
+  name: GIT_SHA1
+  required: true
+
+objects:
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${PREFIX}ciip-postgres-master
+  spec:
+    storageClassName: netapp-block-standard
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20Gi

--- a/openshift/deploy/secret/ciip-postgres-master.yml
+++ b/openshift/deploy/secret/ciip-postgres-master.yml
@@ -1,0 +1,27 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+
+parameters:
+  - description: Prefix to prepend to object name.
+    displayName: Prefix
+    name: PREFIX
+    required: true
+  - description: SHA1 of git revision to be deployed.
+    displayName: Git SHA1
+    name: GIT_SHA1
+    required: true
+  - description: Base64-encoded password for the postgres user.
+    displayName: Postgres Password
+    name: POSTGRESQL_ADMIN_PASSWORD
+    required: true
+
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        beta.kubernetes.io/os: linux
+      name: ${PREFIX}ciip-postgres-master
+    type: Opaque
+    data:
+      postgresqlAdminPassword: ${POSTGRESQL_ADMIN_PASSWORD}

--- a/openshift/deploy/service/ciip-postgres-master.yml
+++ b/openshift/deploy/service/ciip-postgres-master.yml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+
+parameters:
+  - description: Prefix to prepend to object name.
+    displayName: Prefix
+    name: PREFIX
+    required: true
+
+objects:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${PREFIX}ciip-postgres-master
+      labels:
+        name: ${PREFIX}ciip-postgres-master
+    spec:
+      selector:
+        name: ${PREFIX}ciip-postgres-master
+      clusterIP: None
+      ports:
+      - port: 5432


### PR DESCRIPTION
This is a temporary feature until we use helm, after which this commit can be reverted.

This is just a copy-paste of the exisiting templates, with different resources names