### PR TITLE
Feat: postgres operator chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feat/postgres-operator-chart
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - feat/postgres-operator-chart
 
 jobs:
   release:
@@ -28,6 +29,7 @@ jobs:
         run: |
           helm repo add charts-incubator https://charts.helm.sh/incubator
           helm repo add charts-stable https://charts.helm.sh/stable
+          helm repo add cas-pipeline https://bcgov.github.io/cas-pipeline/
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.2.1

--- a/helm/cas-postgres-cluster/.helmignore
+++ b/helm/cas-postgres-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/cas-postgres-cluster/Chart.lock
+++ b/helm/cas-postgres-cluster/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: terraform-bucket-provision
+  repository: https://bcgov.github.io/cas-pipeline/
+  version: 0.1.4
+digest: sha256:280fe796327c1ab225cc094503a2fddda95ff75bf57883f2dbfca25507ed4740
+generated: "2024-08-09T16:17:22.422087-07:00"

--- a/helm/cas-postgres-cluster/Chart.lock
+++ b/helm/cas-postgres-cluster/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.4
-digest: sha256:280fe796327c1ab225cc094503a2fddda95ff75bf57883f2dbfca25507ed4740
-generated: "2024-08-09T16:17:22.422087-07:00"
+digest: sha256:06cdd92bf21283bbd61431e210f1b2a34d750bf2af33044a0002d0d64a156045
+generated: "2024-08-09T19:49:05.803773-07:00"

--- a/helm/cas-postgres-cluster/Chart.yaml
+++ b/helm/cas-postgres-cluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
 
 type: application
 
-version: 0.0.1
+version: 1.0.0
 
 # Postgres Operator version for which this chart has been built.
 # It will very likely work for later versions, in which case the list of compatible images will change.

--- a/helm/cas-postgres-cluster/Chart.yaml
+++ b/helm/cas-postgres-cluster/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: cas-postgres-cluster
+description: |-
+  A Helm chart to deploy a lightweight version of the crunchy PostgresCluster, meant to run in 
+  a small/medium openshift instance of the BC Government.
+  It also configures backups through pgbackrest and a google cloud storage account.
+
+type: application
+
+version: 1.0.0
+
+# Postgres Operator version for which this chart has been built.
+# It will very likely work for later versions, in which case the list of compatible images will change.
+# For the full list of compatible postgres/pgbouncer/pgbackrest versions, see https://access.crunchydata.com/documentation/postgres-operator/latest/references/components
+appVersion: "5.3.1"
+
+dependencies:
+  - name: terraform-bucket-provision
+    version: "0.1.4"
+    repository: https://bcgov.github.io/cas-pipeline/
+    condition: gcsBackups.enable

--- a/helm/cas-postgres-cluster/Chart.yaml
+++ b/helm/cas-postgres-cluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
 
 type: application
 
-version: 1.0.0
+version: 0.0.1
 
 # Postgres Operator version for which this chart has been built.
 # It will very likely work for later versions, in which case the list of compatible images will change.

--- a/helm/cas-postgres-cluster/templates/NetworkPolicy.yaml
+++ b/helm/cas-postgres-cluster/templates/NetworkPolicy.yaml
@@ -1,0 +1,22 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-allow-crunchydb-ha
+  labels: {{ include "cas-postgres-cluster.labels" . | nindent 4 }}
+    postgres-operator.crunchydata.com/cluster: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      postgres-operator.crunchydata.com/cluster: {{ .Release.Name }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              postgres-operator.crunchydata.com/cluster: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 8008
+        - protocol: TCP
+          port: 2022

--- a/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
+++ b/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
@@ -1,0 +1,155 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: {{ include "cas-postgres-cluster.fullname" . }}
+  labels: {{ include "cas-postgres-cluster.labels" . | nindent 4 }}
+spec:
+  # this block is useful only if you also have monitoring set up for your cluster.
+  # this example installation is intended to be as small as possible, so it has been removed.
+  # however, this block remains as an example if you would like to add monitoring to your cluster.
+  #
+  # monitoring:
+  #   pgmonitor:
+  #     # this stuff is for the "exporter" container in the "obps-postgres-pgha1" set of pods
+  #     exporter:
+  #       resources:
+  #         requests:
+  #           cpu: 50m
+  #           memory: 32Mi
+  #         limits:
+  #           cpu: 100m
+  #           memory: 64Mi
+  image: {{ .Values.postgresCluster.postgres.image }}:{{ .Values.postgresCluster.postgres.tag }}
+  metadata:
+    labels: {{ include "cas-postgres-cluster.labels" . | nindent 6 }}
+  postgresVersion: {{ .Values.postgresCluster.postgresVersion }}
+  instances:
+    - name: pgha1
+      replicas: {{ .Values.postgresCluster.postgres.replicaCount }}
+      # this is how you create a PDB - don't make a separate one yourself!
+      minAvailable: 1
+      # these resources are for the "database" container in the "<release-name>-pgha1" set of pods
+      resources: {{ toYaml .Values.postgresCluster.resources | nindent 8 }}
+      sidecars:
+        # this stuff is for the "replication-cert-copy" container in the "<release-name>-pgha1" set of pods
+        replicaCertCopy:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.postgresCluster.storageSize }}
+        storageClassName: netapp-block-standard
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  postgres-operator.crunchydata.com/cluster: {{ template "cas-postgres-cluster.fullname" . }}
+                  postgres-operator.crunchydata.com/instance-set: pgha1
+  users: {{ toYaml .Values.postgresCluster.users | nindent 4 }}
+  backups:
+    pgbackrest:
+      image: {{ .Values.postgresCluster.pgbackrest.image }}:{{ .Values.postgresCluster.pgbackrest.tag }}
+      global:
+        repo1-retention-full: "90"
+        repo1-retention-full-type: time
+{{- if index .Values "gcsBackups" "enable" }}
+      configuration:
+        - configMap:
+            name: {{ template "cas-postgres-cluster.fullname" . }}-pgbackrest
+        - secret:
+            name: gcp-{{ .Release.Namespace }}-{{ .Values.gcsBucket }}-service-account-key
+            items:
+              - key: credentials.json
+                path: gcs-key.json
+{{- end }}
+      repos:
+        - name: repo1
+{{- if index .Values "gcsBackups" "enable" }}
+          gcs:
+            bucket: {{ .Release.Namespace }}-{{ .Values.gcsBackups.bucketName }}
+{{- else }}
+          # We backup to a local PVC
+          volume:
+            volumeClaimSpec:
+              storageClassName: netapp-block-standard
+              accessModes:
+              - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: {{ .Values.postgresCluster.storageSize }}
+{{- end }}
+          schedules:
+            full: "0 8 * * *"
+            # run incremental backup every 4 hours, except at 8am UTC (when the full backup is running)
+            incremental: "0 0,4,12,16,20 * * *"
+      # this stuff is for the "pgbackrest" container (the only non-init container) in the "obps-postgres-repo-host" pod
+      repoHost:
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      sidecars:
+        # this stuff is for the "pgbackrest" container in the "obps-postgres-pgha1" set of pods
+        pgbackrest:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+      # allows the triggering of manual backups
+      manual:
+        repoName: repo1
+        options:
+         - --type=full
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        # these will probably allow your database to start up, but you'll definitely want to tune them up a bit for anything but the most minimal DBs.
+        parameters:
+          shared_buffers: '128MB' # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
+          wal_buffers: '-1' # automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
+          min_wal_size: '32MB'
+          max_wal_size: '500MB' # default is 1GB
+  proxy:
+    pgBouncer:
+      image: {{ .Values.postgresCluster.pgbouncer.image }}:{{ .Values.postgresCluster.pgbouncer.tag }}
+      config:
+        global:
+          client_tls_sslmode: disable
+      replicas: {{ .Values.postgresCluster.pgbouncer.replicaCount }}
+      # these resources are for the "pgbouncer" container in the "obps-postgres-pgbouncer" set of pods
+      # there is a sidecar in these pods which are not mentioned here, but the requests/limits are teeny weeny by default so no worries there.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 64Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  postgres-operator.crunchydata.com/cluster: {{ template "cas-postgres-cluster.fullname" . }}
+                  postgres-operator.crunchydata.com/role: pgbouncer

--- a/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
+++ b/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
@@ -19,7 +19,9 @@ spec:
   #         limits:
   #           cpu: 100m
   #           memory: 64Mi
+{{- if and (index .Values "postgresCluster" "postgres" "image") (index .Values "postgresCluster" "postgres" "tag") }}
   image: {{ .Values.postgresCluster.postgres.image }}:{{ .Values.postgresCluster.postgres.tag }}
+{{- end }}
   metadata:
     labels: {{ include "cas-postgres-cluster.labels" . | nindent 6 }}
   postgresVersion: {{ .Values.postgresCluster.postgresVersion }}
@@ -60,7 +62,9 @@ spec:
   users: {{ toYaml .Values.postgresCluster.users | nindent 4 }}
   backups:
     pgbackrest:
+{{- if and (index .Values "postgresCluster" "pgbackrest" "image") (index .Values "postgresCluster" "pgbackrest" "tag") }}
       image: {{ .Values.postgresCluster.pgbackrest.image }}:{{ .Values.postgresCluster.pgbackrest.tag }}
+{{- end }}
       global:
         repo1-retention-full: "90"
         repo1-retention-full-type: time
@@ -129,7 +133,9 @@ spec:
           max_wal_size: '500MB' # default is 1GB
   proxy:
     pgBouncer:
+{{- if and (index .Values "postgresCluster" "pgbouncer" "image") (index .Values "postgresCluster" "pgbouncer" "tag") }}
       image: {{ .Values.postgresCluster.pgbouncer.image }}:{{ .Values.postgresCluster.pgbouncer.tag }}
+{{- end }}
       config:
         global:
           client_tls_sslmode: disable

--- a/helm/cas-postgres-cluster/templates/_helpers.tpl
+++ b/helm/cas-postgres-cluster/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cas-postgres-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cas-postgres-cluster.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cas-postgres-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Gets the prefix of the namespace. (<openshift_nameplate>, ... )
+*/}}
+{{- define "cas-postgres-cluster.namespacePrefix" }}
+{{- (split "-" .Release.Namespace)._0 | trim -}}
+{{- end }}
+
+{{/*
+Gets the suffix of the namespace. (-dev, -tools, ... )
+*/}}
+{{- define "cas-postgres-cluster.namespaceSuffix" }}
+{{- (split "-" .Release.Namespace)._1 | trim -}}
+{{- end }}
+
+{{/*
+Create an app-name appended with environment. (app-name-dev, app-name-tools, ... )
+*/}}
+{{- define "cas-postgres-cluster.nameWithEnvironment" }}
+{{- printf "%s-%s" .Chart.Name  (split "-" .Release.Namespace)._1 }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cas-postgres-cluster.labels" -}}
+helm.sh/chart: {{ include "cas-postgres-cluster.chart" . }}
+{{ include "cas-postgres-cluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cas-postgres-cluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cas-postgres-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cas-postgres-cluster.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cas-postgres-cluster.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+

--- a/helm/cas-postgres-cluster/templates/allowExternalAccess.yaml
+++ b/helm/cas-postgres-cluster/templates/allowExternalAccess.yaml
@@ -1,0 +1,21 @@
+{{- if index .Values "external-access" "enable" }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ .Release.name }}-cas-postgres-external-access
+  labels: {{ include "cas-postgres-cluster.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      postgres-operator.crunchydata.com/role: replica
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Values.externalAccess.instanceName }}
+          namespaceSelector:
+            matchLabels:
+              environment: {{ .Values.externalAccess.environment }}
+              name: {{ .Values.externalAccess.prefix }}
+{{- end }}

--- a/helm/cas-postgres-cluster/templates/pgbackrest-config.yaml
+++ b/helm/cas-postgres-cluster/templates/pgbackrest-config.yaml
@@ -1,0 +1,11 @@
+{{- if index .Values "gcsBackups" "enable" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cas-postgres-cluster.fullname" . }}-pgbackrest
+  labels: {{ include "cas-postgres-cluster.labels" . | nindent 4 }}
+data:
+  gcs.conf: |-
+    [global]
+      repo1-gcs-key=/etc/pgbackrest/conf.d/gcs-key.json
+{{- end }}

--- a/helm/cas-postgres-cluster/values-dev.yaml
+++ b/helm/cas-postgres-cluster/values-dev.yaml
@@ -1,0 +1,11 @@
+environment: dev
+
+postgres-cluster:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/helm/cas-postgres-cluster/values-prod.yaml
+++ b/helm/cas-postgres-cluster/values-prod.yaml
@@ -1,0 +1,12 @@
+environment: prod
+
+postgres-cluster:
+  storageSize: 3Gi
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 150m
+      memory: 150Mi
+    limits:
+      cpu: 600m
+      memory: 600Mi

--- a/helm/cas-postgres-cluster/values-test.yaml
+++ b/helm/cas-postgres-cluster/values-test.yaml
@@ -1,0 +1,11 @@
+environment: test
+
+postgres-cluster:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/helm/cas-postgres-cluster/values.yaml
+++ b/helm/cas-postgres-cluster/values.yaml
@@ -16,12 +16,12 @@ postgresCluster:
     image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres
     tag: ubi8-15.7-0
     replicaCount: 1
-  pgbackrest:
-    image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest
-    tag: ubi8-2.41-4
+  # pgbackrest:
+  #   image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest
+  #   tag: ubi8-2.41-4
   pgbouncer:
-    image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer
-    tag: ubi8-1.18-0
+    # image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer
+    # tag: ubi8-1.18-0
     replicaCount: 2
 
   # The "users" value(s) is passed to the crunchy postgres operator to create the database.

--- a/helm/cas-postgres-cluster/values.yaml
+++ b/helm/cas-postgres-cluster/values.yaml
@@ -1,0 +1,52 @@
+# dev, test, prod
+environment: ~
+
+postgresCluster:
+  postgresVersion: 15
+  storageSize: 1Gi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+
+  postgres:
+    image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-postgres
+    tag: ubi8-15.7-0
+    replicaCount: 1
+  pgbackrest:
+    image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbackrest
+    tag: ubi8-2.41-4
+  pgbouncer:
+    image: artifacts.developer.gov.bc.ca/bcgov-docker-local/crunchy-pgbouncer
+    tag: ubi8-1.18-0
+    replicaCount: 2
+
+  # The "users" value(s) is passed to the crunchy postgres operator to create the database.
+  # See https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management
+  users:
+    - name: postgres
+      databases:
+        - test
+
+gcsBackups:
+  enable: false
+  # Needs to match the "namespace_apps" value in the terraform provisioning chart.
+  # example syntax: bucketName
+  bucketName: ~
+
+terraform-bucket-provision:
+  terraform:
+    # example syntax: '["bucketName"]'
+    namespace_apps: ~
+    # !important: unique for the deployment
+    workspace: ~
+
+# To configure a KNP allowing external access, for metabase for example
+external-access:
+  enabled: false
+  instanceName: cas-metabase
+  prefix: ~
+  environment: ~


### PR DESCRIPTION
A chart to deploy a postgres operator to the openshift cluster.
The chart is preconfigured to use CAS backup strategy with GCS