### PR TITLE
Fix/explicit openshift flag

### DIFF
--- a/helm/cas-postgres-cluster/Chart.yaml
+++ b/helm/cas-postgres-cluster/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
 
 type: application
 
-version: 1.1.2
+version: 1.1.3
 
 # Postgres Operator version for which this chart has been built.
 # It will very likely work for later versions, in which case the list of compatible images will change.

--- a/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
+++ b/helm/cas-postgres-cluster/templates/PostgresCluster.yaml
@@ -22,6 +22,7 @@ spec:
 {{- if and (index .Values "postgresCluster" "postgres" "image") (index .Values "postgresCluster" "postgres" "tag") }}
   image: {{ .Values.postgresCluster.postgres.image }}:{{ .Values.postgresCluster.postgres.tag }}
 {{- end }}
+  openshift: true
   metadata:
     labels: {{ include "cas-postgres-cluster.labels" . | nindent 6 }}
   postgresVersion: {{ .Values.postgresCluster.postgresVersion }}


### PR DESCRIPTION
Fix for failing autodetection of OpenShift by the Postgres Operator. We're always deploying into OpenShift, so we explicitly set it. 